### PR TITLE
Adding the description from the OpenAPI component to the proto message

### DIFF
--- a/generator/testfiles/goldstandard/other.proto
+++ b/generator/testfiles/goldstandard/other.proto
@@ -28,6 +28,7 @@ message Person {
   float iq = 7;
 }
 
+//TestExernalReference2Parameters holds parameters to TestExernalReference2
 message TestExernalReference2Request {
   parameters.Parameter2 parameter2 = 1;
 }

--- a/generator/testfiles/goldstandard/parameters.proto
+++ b/generator/testfiles/goldstandard/parameters.proto
@@ -16,10 +16,12 @@ message Parameter2 {
   int64 param8 = 1;
 }
 
+//TestParameterQueryParameters holds parameters to TestParameterQuery
 message TestParameterQueryRequest {
   int32 param1 = 1;
 }
 
+//TestParameterQueryEnumParameters holds parameters to TestParameterQueryEnum
 message TestParameterQueryEnumRequest {
   repeated Param2 param2 = 1;
 
@@ -32,10 +34,12 @@ message TestParameterQueryEnumRequest {
   }
 }
 
+//TestParameterPathParameters holds parameters to TestParameterPath
 message TestParameterPathRequest {
   string param3 = 1;
 }
 
+//TestParameterPathEnumParameters holds parameters to TestParameterPathEnum
 message TestParameterPathEnumRequest {
   Param4 param4 = 1;
 
@@ -46,12 +50,14 @@ message TestParameterPathEnumRequest {
   }
 }
 
+//TestParameterMultiplePathParameters holds parameters to TestParameterMultiplePath
 message TestParameterMultiplePathRequest {
   string param5 = 1;
 
   string param6 = 2;
 }
 
+//TestParameterReferenceParameters holds parameters to TestParameterReference
 message TestParameterReferenceRequest {
   Parameter1 parameter1 = 1;
 }

--- a/generator/testfiles/goldstandard/requestbodies.proto
+++ b/generator/testfiles/goldstandard/requestbodies.proto
@@ -18,10 +18,12 @@ message Person {
   repeated string photo_urls = 4;
 }
 
+//TestRequestBodyParameters holds parameters to TestRequestBody
 message TestRequestBodyRequest {
   Person person = 1;
 }
 
+//TestRequestBodyReferenceParameters holds parameters to TestRequestBodyReference
 message TestRequestBodyReferenceRequest {
   Person person = 1;
 }


### PR DESCRIPTION
Fixes #32 

For OpenAPI components, comments will be generated. 
Not for specific properties of the component though.