### PR TITLE
prototype for potential traverse and scan separation solution

### DIFF
--- a/incompatibility/incompatibility-report/object.go
+++ b/incompatibility/incompatibility-report/object.go
@@ -1,0 +1,12 @@
+package incompatibility
+
+type ObjectID int
+
+const (
+	Document = iota
+	Parameters
+	Components
+	Operation
+	Schema
+	Path
+)

--- a/incompatibility/incompatibility-report/openapi-document.go
+++ b/incompatibility/incompatibility-report/openapi-document.go
@@ -51,6 +51,7 @@ func (d DocumentTraverse) traverse(i interface{}) []*Incompatibility {
 		}
 		// traverse document
 		for _, childTraverse := range d.paths {
+			// child will have to know how to get from doc level to child level, see paths
 			incompatibilities = append(incompatibilities, childTraverse.traverse(doc)...)
 		}
 	}

--- a/incompatibility/incompatibility-report/openapi-document.go
+++ b/incompatibility/incompatibility-report/openapi-document.go
@@ -1,0 +1,58 @@
+package incompatibility
+
+import openapiv3 "github.com/googleapis/gnostic/openapiv3"
+
+type OpenAPIDocumentRule struct {
+	doc      *openapiv3.Document
+	ruleFunc func(*openapiv3.Document) *Incompatibility
+}
+
+func NewDocRule(scanner func(*openapiv3.Document) *Incompatibility) OpenAPIDocumentRule {
+	return OpenAPIDocumentRule{ruleFunc: scanner}
+}
+
+func (docRules *OpenAPIDocumentRule) SetInputDoc(doc *openapiv3.Document) {
+	docRules.doc = doc
+}
+
+func (docRules OpenAPIDocumentRule) ObjectKind() ObjectID {
+	return Document
+}
+
+func (docRules OpenAPIDocumentRule) ScanIncompatibility() *Incompatibility {
+	return docRules.ruleFunc(docRules.doc)
+}
+
+type DocumentTraverse struct {
+	rules []OpenAPIDocumentRule
+	paths []OpenAPITraversal
+}
+
+func NewDocTraverse(paths ...OpenAPITraversal) DocumentTraverse {
+	return DocumentTraverse{paths: paths}
+}
+
+func (d DocumentTraverse) acceptIncompatibilityRule(incompatibilityRules ...OpenAPIIncompatibilityRule) {
+	for _, rule := range incompatibilityRules {
+		if rule.ObjectKind() == Document {
+			d.rules = append(d.rules, rule.(OpenAPIDocumentRule))
+		}
+	}
+}
+
+func (d DocumentTraverse) traverse(i interface{}) []*Incompatibility {
+	var incompatibilities []*Incompatibility
+	doc, conversion := i.(*openapiv3.Document)
+	if conversion {
+		//Scan for incompatibilities
+		for _, rule := range d.rules {
+			rule.SetInputDoc(doc)
+			incompatibilities = append(incompatibilities, rule.ScanIncompatibility())
+		}
+		// traverse document
+		for _, childTraverse := range d.paths {
+			incompatibilities = append(incompatibilities, childTraverse.traverse(doc)...)
+		}
+	}
+	return incompatibilities
+}

--- a/incompatibility/incompatibility-report/openapi-incomp.go
+++ b/incompatibility/incompatibility-report/openapi-incomp.go
@@ -1,0 +1,19 @@
+// Copyright 2021 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package incompatibility
+
+type OpenAPIIncompatibilityRule interface {
+	ObjectKind() ObjectID
+	ScanIncompatibility() *Incompatibility
+}

--- a/incompatibility/incompatibility-report/openapi-paths.go
+++ b/incompatibility/incompatibility-report/openapi-paths.go
@@ -49,7 +49,7 @@ func (p ParamTraverse) traverse(i interface{}) []*Incompatibility {
 			incompatibilities = append(incompatibilities, p.traverseTyped(path.Value)...)
 		}
 	case *openapiv3.PathItem:
-		p.traverseTyped(i)
+		incompatibilities = append(incompatibilities, p.traverseTyped(i)...)
 
 	}
 	return incompatibilities

--- a/incompatibility/incompatibility-report/openapi-paths.go
+++ b/incompatibility/incompatibility-report/openapi-paths.go
@@ -1,0 +1,70 @@
+package incompatibility
+
+import openapiv3 "github.com/googleapis/gnostic/openapiv3"
+
+type OpenAPIPathRule struct {
+	path     *openapiv3.PathItem
+	ruleFunc func(*openapiv3.PathItem) *Incompatibility
+}
+
+func NewParamRule(scanner func(*openapiv3.PathItem) *Incompatibility) OpenAPIPathRule {
+	return OpenAPIPathRule{ruleFunc: scanner}
+}
+
+func (paramRule *OpenAPIPathRule) SetInputDoc(path *openapiv3.PathItem) {
+	paramRule.path = path
+}
+
+func (paramRule OpenAPIPathRule) ObjectKind() ObjectID {
+	return Parameters
+}
+
+func (paramRule OpenAPIPathRule) ScanIncompatibility() *Incompatibility {
+	return paramRule.ruleFunc(paramRule.path)
+}
+
+type ParamTraverse struct {
+	rules []OpenAPIPathRule
+	paths []OpenAPITraversal
+}
+
+func NewParamTraverse(paths ...OpenAPITraversal) DocumentTraverse {
+	return DocumentTraverse{paths: paths}
+}
+
+func (p ParamTraverse) acceptIncompatibilityRule(incompatibilityRules ...OpenAPIIncompatibilityRule) {
+	for _, rule := range incompatibilityRules {
+		if rule.ObjectKind() == Path {
+			p.rules = append(p.rules, rule.(OpenAPIPathRule))
+		}
+	}
+}
+
+func (p ParamTraverse) traverse(i interface{}) []*Incompatibility {
+	var incompatibilities []*Incompatibility
+	switch i := i.(type) {
+	case *openapiv3.Document:
+		// At document level, move down to paths
+		for _, path := range i.GetPaths().GetPath() {
+			incompatibilities = append(incompatibilities, p.traverseTyped(path.Value)...)
+		}
+	case *openapiv3.PathItem:
+		p.traverseTyped(i)
+
+	}
+	return incompatibilities
+}
+
+func (p ParamTraverse) traverseTyped(path *openapiv3.PathItem) []*Incompatibility {
+	var incompatibilities []*Incompatibility
+	//Scan for incompatibilities
+	for _, rule := range p.rules {
+		rule.SetInputDoc(path)
+		incompatibilities = append(incompatibilities, rule.ScanIncompatibility())
+	}
+	// traverse document
+	for _, childTraverse := range p.paths {
+		incompatibilities = append(incompatibilities, childTraverse.traverse(path)...)
+	}
+	return incompatibilities
+}

--- a/incompatibility/incompatibility-report/openapi-traversal.go
+++ b/incompatibility/incompatibility-report/openapi-traversal.go
@@ -1,0 +1,19 @@
+// Copyright 2021 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package incompatibility
+
+type OpenAPITraversal interface {
+	acceptIncompatibilityRule(...OpenAPIIncompatibilityRule) // New rules to scan for incompatibilities
+	traverse(interface{}) []*Incompatibility                 //
+}

--- a/incompatibility/incompatibility-report/openapi-traversal.go
+++ b/incompatibility/incompatibility-report/openapi-traversal.go
@@ -15,5 +15,5 @@ package incompatibility
 
 type OpenAPITraversal interface {
 	acceptIncompatibilityRule(...OpenAPIIncompatibilityRule) // New rules to scan for incompatibilities
-	traverse(interface{}) []*Incompatibility                 //
+	traverse(interface{}) []*Incompatibility                 // 'traverse' through rest of document
 }


### PR DESCRIPTION
- This solution hopes to separate traversing through an openapi doc and incompatibility scanning at each level.
     - OpenAPIIncompatibilityRule is an incompatibility-scanning interface which can present an identifier to demonstrate on what OpenAPI object it can scan on and a function which reports a single incompatibility 
     - OpenAPITraversal is a traversal interface which requires  the ability to accept one or more OpenAPIIncompatibilityRule and it has a traverse function which given any input should return a list of incompatibilities.
     -  These interfaces were made to be abstract and to keep each section of logic separated when possible. I implemented a struct for each of these interfaces for a OpenAPI document at openapi-document.go and for a OpenAPI path item at openapi-paths.go