### PR TITLE
Update docs `How to use` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,16 @@ Under the hood the plugin first creates a FileDescriptorSet (`bookststore.descr`
 data. Then [protoreflect](https://github.com/jhump/protoreflect/) is used to print the output file. 
 
 ## How to use: 
+Install gnostic and the plugin -
 
 ### Before Go 1.17
-Install gnostic and the plugin:
-    
+
     go get -u github.com/googleapis/gnostic
     go get -u github.com/googleapis/gnostic-grpc
     
 
-### Wtih Go >= 1.17
-Install gnostic and the plugin:
-    
+### Wtih Go >= 1.17    
+
     go install github.com/googleapis/gnostic@latest
     go install github.com/googleapis/gnostic-grpc@latest
 

--- a/README.md
+++ b/README.md
@@ -22,15 +22,13 @@ Under the hood the plugin first creates a FileDescriptorSet (`bookststore.descr`
 data. Then [protoreflect](https://github.com/jhump/protoreflect/) is used to print the output file. 
 
 ## How to use: 
-Install gnostic and the plugin -
-
-### Before Go 1.17
+Install gnostic and the plugin before Go 1.17:
 
     go get -u github.com/googleapis/gnostic
     go get -u github.com/googleapis/gnostic-grpc
     
 
-### Wtih Go >= 1.17    
+with Go >= 1.17:
 
     go install github.com/googleapis/gnostic@latest
     go install github.com/googleapis/gnostic-grpc@latest

--- a/README.md
+++ b/README.md
@@ -21,11 +21,20 @@ gnostic plugin.
 Under the hood the plugin first creates a FileDescriptorSet (`bookststore.descr`) from the input
 data. Then [protoreflect](https://github.com/jhump/protoreflect/) is used to print the output file. 
 
-## How to use:    
+## How to use: 
+
+### Before Go 1.17
 Install gnostic and the plugin:
     
-    go get -u github.com/google/gnostic
-    go get -u github.com/google/gnostic-grpc
+    go get -u github.com/googleapis/gnostic
+    go get -u github.com/googleapis/gnostic-grpc
+    
+
+### Wtih Go >= 1.17
+Install gnostic and the plugin:
+    
+    go install github.com/googleapis/gnostic@latest
+    go install github.com/googleapis/gnostic-grpc@latest
 
 Run gnostic with the plugin:
 


### PR DESCRIPTION
Since `go.mod` now points to `github.com/googleapis/...`. Plus added new `go install` section, since installation executables with `go get` is now [deprecated](https://golang.org/doc/go-get-install-deprecation)