### PR TITLE
Addressing Install fails while parsing go.mod #77

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install gnostic and the plugin before Go 1.17:
 with Go >= 1.17:
 
     go install github.com/google/gnostic@latest
-    go install github.com/google/gnostic-grpc@latest
+    go install github.com/googleapis/gnostic-grpc@latest
 
 Run gnostic with the plugin:
 


### PR DESCRIPTION
The `go install github.com/google/gnostic-grpc@latest` command in the readme fails with the error:

```
go install: github.com/google/gnostic-grpc@latest: github.com/google/gnostic-grpc@v0.1.1: parsing go.mod:
	module declares its path as: github.com/googleapis/gnostic-grpc
	        but was required as: github.com/google/gnostic-grpc
```

I'm not sure why `go install github.com/google/gnostic@latest` still works.