### PR TITLE
fix: deduplicate message properties, message descriptors

### DIFF
--- a/generator/generator_messages.go
+++ b/generator/generator_messages.go
@@ -29,6 +29,7 @@ func buildAllMessageDescriptors(renderer *Renderer) (messageDescriptors []*dpb.D
 			}
 			if isRequestParameter(surfaceType) {
 				validateRequestParameter(surfaceField)
+				message.Name = &surfaceType.Name
 			}
 
 			addFieldDescriptor(message, surfaceField, i, renderer.Package)
@@ -84,11 +85,8 @@ func copyField(f *surface_v1.Field) *surface_v1.Field {
 }
 
 // isRequestParameter checks whether 't' is a type that will be used as a request parameter for a RPC method.
-func isRequestParameter(sufaceType *surface_v1.Type) bool {
-	if strings.Contains(sufaceType.Description, sufaceType.GetName()+" holds parameters to") {
-		return true
-	}
-	return false
+func isRequestParameter(surfaceType *surface_v1.Type) bool {
+	return strings.Contains(surfaceType.Description, surfaceType.GetName()+" holds parameters to")
 }
 
 func validateRequestParameter(field *surface_v1.Field) {
@@ -179,7 +177,7 @@ func fieldHasAReferenceToAMessageInAnotherDependency(field *surface_v1.Field, fi
 	return fieldDescriptorType == dpb.FieldDescriptorProto_TYPE_MESSAGE && messageExists
 }
 
-// getFieldDescriptorLabel returns the label for the descriptor based on the information in he surface field.
+// getFieldDescriptorLabel returns the label for the descriptor based on the information in the surface field.
 func getFieldDescriptorLabel(f *surface_v1.Field) *dpb.FieldDescriptorProto_Label {
 	label := dpb.FieldDescriptorProto_LABEL_OPTIONAL
 	if f.Kind == surface_v1.FieldKind_ARRAY || strings.Contains(f.NativeType, "map") {

--- a/generator/generator_messages.go
+++ b/generator/generator_messages.go
@@ -29,6 +29,7 @@ func buildAllMessageDescriptors(renderer *Renderer) (messageDescriptors []*dpb.D
 			}
 			if isRequestParameter(surfaceType) {
 				validateRequestParameter(surfaceField)
+				// convert base message to parameter message, e.g., GetPetRequest -> GetPetParameters
 				message.Name = &surfaceType.Name
 			}
 

--- a/generator/generator_service.go
+++ b/generator/generator_service.go
@@ -42,7 +42,7 @@ func buildMethodDescriptor(method *surface_v1.Method, types []*surface_v1.Type) 
 	if err != nil {
 		return nil, err
 	}
-	inputType, outputType := buildInputTypeAndOutputType(method.ParametersTypeName, method.ResponsesTypeName)
+	inputType, outputType := buildInputTypeAndOutputType(method.ParametersTypeName, method.ResponsesTypeName, types)
 	methodDescriptor = &dpb.MethodDescriptorProto{
 		Name:       &method.HandlerName,
 		InputType:  &inputType,
@@ -120,7 +120,7 @@ func getRequestBodyForRequestParameter(name string, types []*surface_v1.Type) st
 	return ""
 }
 
-func buildInputTypeAndOutputType(parametersTypeName string, responseTypeName string) (inputType string, outputType string) {
+func buildInputTypeAndOutputType(parametersTypeName, responseTypeName string, types []*surface_v1.Type) (inputType, outputType string) {
 	inputType = parametersTypeName
 	outputType = responseTypeName
 	if parametersTypeName == "" {
@@ -128,6 +128,11 @@ func buildInputTypeAndOutputType(parametersTypeName string, responseTypeName str
 	}
 	if responseTypeName == "" {
 		outputType = "google.protobuf.Empty"
+	}
+	for _, t := range types {
+		if t.TypeName == inputType && t.Name != inputType {
+			inputType = t.Name
+		}
 	}
 	return inputType, outputType
 }

--- a/generator/generator_service.go
+++ b/generator/generator_service.go
@@ -130,6 +130,7 @@ func buildInputTypeAndOutputType(parametersTypeName, responseTypeName string, ty
 		outputType = "google.protobuf.Empty"
 	}
 	for _, t := range types {
+		// convert base input type to parameter input type, e.g., GetPetRequest -> GetPetParameters
 		if t.TypeName == inputType && t.Name != inputType {
 			inputType = t.Name
 		}


### PR DESCRIPTION
- fixes #69
- fixes a previously unreported issue where duplicate message descriptors are generated for POST requests with an object ref in their body